### PR TITLE
Switch to preact for faster loading

### DIFF
--- a/src/st_copy/frontend/package-lock.json
+++ b/src/st_copy/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "preact": "^10.26.8",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "streamlit-component-lib": "^2.0.0"
@@ -3186,6 +3187,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.26.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.8.tgz",
+      "integrity": "sha512-1nMfdFjucm5hKvq0IClqZwK4FJkGXhRrQstOQ3P4vp8HxKrJEMFcY6RdBRVTdfQS/UlnX6gfbPuTvaqx/bDoeQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prelude-ls": {

--- a/src/st_copy/frontend/package.json
+++ b/src/st_copy/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "preact": "^10.26.8",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "streamlit-component-lib": "^2.0.0"

--- a/src/st_copy/frontend/vite.config.ts
+++ b/src/st_copy/frontend/vite.config.ts
@@ -1,8 +1,19 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+// Use Preact to shrink bundle size
+const alias = {
+  react: 'preact/compat',
+  'react-dom': 'preact/compat',
+  'react-dom/client': 'preact/compat',
+  'react/jsx-runtime': 'preact/jsx-runtime',
+}
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias,
+  },
   base: './',
 })


### PR DESCRIPTION
## Summary
- use preact/compat in the frontend build
- add preact dependency

## Testing
- `uv run pre-commit run --all-files --show-diff-on-failure`
- `npm ci --prefix src/st_copy/frontend --no-audit --no-fund`
- `npm run --prefix src/st_copy/frontend build`
- `uv run pytest -vv --junitxml=report.xml --cov=src --cov-report=xml --cov-report=term`
- `uv build`
- `unzip -l dist/*.whl | grep frontend/dist/index.html`


------
https://chatgpt.com/codex/tasks/task_e_6841e3aec3208331a51748de1c5c9449