### PR TITLE
Optimize CopyButton handlers with hooks

### DIFF
--- a/src/st_copy/frontend/src/CopyButton.tsx
+++ b/src/st_copy/frontend/src/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import {
   ComponentProps,
   withStreamlitConnection,
@@ -23,7 +23,7 @@ function CopyButton({ args, theme }: ComponentProps) {
   }, [])
 
   // Handle click → copy → visual feedback → notify Python
-  const copyHandler = async () => {
+  const copyHandler = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);
@@ -35,26 +35,27 @@ function CopyButton({ args, theme }: ComponentProps) {
     } catch {
       Streamlit.setComponentValue(false);
     }
-  };
+  }, [text]);
 
-  const renderIcon = () => {
+  const iconElement = useMemo(() => {
     if (icon === "st") {
       // Native Streamlit code‑block icon
       return (
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-          </svg>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+        </svg>
       );
     }
 
@@ -68,10 +69,10 @@ function CopyButton({ args, theme }: ComponentProps) {
         fill="currentColor"
         aria-hidden="true"
       >
-        <path d="M360-240q-29.7 0-50.85-21.15Q288-282.3 288-312v-480q0-29.7 21.15-50.85Q330.3-864 360-864h384q29.7 0 50.85 21.15Q816-821.7 816-792v480q0 29.7-21.15 50.85Q773.7-240 744-240H360Zm0-72h384v-480H360v480ZM216-96q-29.7 0-50.85-21.15Q144-138.3 144-168v-552h72v552h456v72H216Zm144-216v-480 480Z"/>
+        <path d="M360-240q-29.7 0-50.85-21.15Q288-282.3 288-312v-480q0-29.7 21.15-50.85Q330.3-864 360-864h384q29.7 0 50.85 21.15Q816-821.7 816-792v480q0 29.7-21.15 50.85Q773.7-240 744-240H360Zm0-72h384v-480H360v480ZM216-96q-29.7 0-50.85-21.15Q144-138.3 144-168v-552h72v552h456v72H216Zm144-216v-480 480Z" />
       </svg>
     );
-  };
+  }, [icon]);
 
   return (
     <button
@@ -80,7 +81,7 @@ function CopyButton({ args, theme }: ComponentProps) {
       title={tooltip ?? "Copy"}
       style={{ color: theme?.textColor }}
     >
-      {renderIcon()}
+      {iconElement}
 
       {/* Always in DOM, but hidden by default */}
       <span className="st-copy-label">


### PR DESCRIPTION
## Summary
- memoize `copyHandler` and icon rendering in `CopyButton`

## Testing
- `uv run pre-commit run --all-files --show-diff-on-failure`
- `npm run --prefix src/st_copy/frontend build`
- `uv run pytest -vv --junitxml=report.xml --cov=src --cov-report=xml --cov-report=term`
- `uv build`
- `unzip -l dist/*.whl | grep frontend/dist/index.html`


------
https://chatgpt.com/codex/tasks/task_e_6841f838262483319d6c92b1b5fc6566